### PR TITLE
Expose MetroHash128::finish128 function

### DIFF
--- a/src/metrohash128.rs
+++ b/src/metrohash128.rs
@@ -43,7 +43,7 @@ impl MetroHash128 {
     }
 
     #[inline]
-    fn finish128(&self) -> (u64, u64) {
+    pub fn finish128(&self) -> (u64, u64) {
         // copy internal state
         let mut v = self.v;
 


### PR DESCRIPTION
I couldn't find another way to get 128-bit output